### PR TITLE
Fix crash when loading UI with custom widgets.

### DIFF
--- a/src/Quiver.cpp
+++ b/src/Quiver.cpp
@@ -26,6 +26,10 @@
 #include <gst/gst.h>
 #endif
 
+#include "libquiver/quiver-icon-view.h"
+#include "libquiver/quiver-image-view.h"
+#include "libquiver/quiver-navigation-control.h"
+
 gchar g_szConfigFilePath[1024];
 
 // No class definition here
@@ -122,6 +126,9 @@ int main (int argc, char *argv[])
 #if !GLIB_CHECK_VERSION(2,35,0)
     g_type_init();
 #endif
+    quiver_icon_view_get_type();
+    quiver_image_view_get_type();
+    quiver_navigation_control_get_type();
 
     GtkApplication* app = gtk_application_new("org.quiver.quiver", G_APPLICATION_HANDLES_OPEN);
 


### PR DESCRIPTION
The application was crashing when loading UI files that contained the custom `QuiverIconView`, `QuiverImageView`, and `QuiverNavigationControl` widgets. This was because these widgets were not registered with the GObject type system before `GtkBuilder` attempted to instantiate them.

This change fixes the crash by explicitly registering the custom widget types at the beginning of the `main` function, ensuring they are known to the type system before the UI is loaded.